### PR TITLE
Braid group

### DIFF
--- a/CQTS/BraidGroups.agda
+++ b/CQTS/BraidGroups.agda
@@ -147,13 +147,9 @@ circMap : (n : ℕ) →  S¹ → Bouquet (Fin n)
 circMap n s = circleHelper n n s
 
 -- Defining a circle structure
-CircleStructure :  Type → Type 
-CircleStructure A = Σ (n : ℕ) (f : S¹ → Bouquet A) , (f ≡ circMap n)
--- CircleEquivStr : {!   !}
--- CircleEquivStr A B f = {!   !}
+-- CircleStructure :  Type → Type 
+-- CircleStructure A = Σ (n : ℕ) (f : S¹ → Bouquet A) , (f ≡ circMap n)
 
--- CircleUnivalentStr :  {!   !}
--- CircleUnivalentStr f =  {!   !}
 
-BouquetCircStr : (n : ℕ) → TypeWithStr _ CircleStructure
+BouquetCircStr : (n : ℕ) → TypeWithStr _ {!   !}
 BouquetCircStr n = Bouquet (Fin n) , circMap n 

--- a/CQTS/BraidGroups.agda
+++ b/CQTS/BraidGroups.agda
@@ -13,7 +13,11 @@ open import Cubical.Data.Nat.Order
 
 open import Cubical.Foundations.SIP
 open import Cubical.Structures.Pointed
+open import Cubical.HITs.S1.Base
 
+private
+  variable
+    ℓ : Level
 
 data Bouquet3 : Type where 
   base : Bouquet3
@@ -98,7 +102,7 @@ encodeDecodeAutomorph zero (loop (x , p) i) j =  lemma i j
         lemma = ⊥.rec (¬-<-zero p) 
 encodeDecodeAutomorph (suc zero) b = refl
 encodeDecodeAutomorph (suc (suc n)) base = refl
-encodeDecodeAutomorph (suc (suc n)) (loop (zero , p) i) = {!   !}
+encodeDecodeAutomorph (suc (suc n)) (loop (zero , p) i) = {!  !}
 encodeDecodeAutomorph (suc (suc n)) (loop (suc zero , p) i) j  = loop (suc zero , isProp≤ (suc-≤-suc (suc-≤-suc (zero-≤ ))) p j) i
 encodeDecodeAutomorph (suc (suc n)) (loop (suc (suc x) , p) i) = refl
 
@@ -125,3 +129,21 @@ snd (MyIsomoprhPtdEquiv (suc (suc n))) = refl
 
 MyIsomorphPtdPath : (n : ℕ) → BouquetStr n ≡ BouquetStr n
 MyIsomorphPtdPath n = pointed-sip (BouquetStr n) (BouquetStr n) (MyIsomoprhPtdEquiv n)
+
+circleHelper : (k : ℕ) →  (n : ℕ) →  S¹ → Bouquet (Fin n)
+circleHelper k zero s = base
+circleHelper k (suc zero) base = base
+circleHelper k (suc zero) (loop i) = loop (zero , ≤-refl) i
+circleHelper zero (suc (suc n)) base = base
+circleHelper zero (suc (suc n)) (loop i) = loop (zero , (suc-≤-suc (≤-suc zero-≤))) i
+circleHelper (suc k) (suc (suc n)) base = base
+circleHelper (suc k) (suc (suc n)) (loop i) = ( {! circleHelper ? ? ? !} ∙ loop (suc k , {!   !})) i
+
+-- (circleHelper k (suc (suc n)) (loop i))
+
+circMap : (n : ℕ) →  S¹ → Bouquet (Fin n)
+circMap n s = circleHelper n n s
+
+BouquetCircStr : (n : ℕ) → TypeWithStr {! ℓ !} {!   !} 
+BouquetCircStr n = Bouquet (Fin n) , circMap
+

--- a/CQTS/BraidGroups.agda
+++ b/CQTS/BraidGroups.agda
@@ -1,3 +1,74 @@
 module CQTS.BraidGroups where
 
-import Cubical.Algebra.Group
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism 
+open import Cubical.Data.Empty as ⊥
+
+open import Cubical.Algebra.Group
+open import Cubical.HITs.Bouquet
+open import Cubical.Data.Fin
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; _+_ ; znots)
+open import Cubical.Data.Nat.Order
+
+
+
+data Bouquet3 : Type where 
+  base : Bouquet3
+  loop1 : base ≡ base
+  loop2 : base ≡ base
+  loop3 : base ≡ base 
+
+automorph : Bouquet3 → Bouquet3
+automorph base = base
+automorph (loop1 i) = (loop1 ∙ loop2 ∙ loop3 ∙ (sym loop2) ∙ (sym loop1)) i
+automorph (loop2 i) = loop2 i
+automorph (loop3 i) = (sym loop2 ∙ loop1 ∙ loop2) i
+
+
+data ThreeThings : Type where
+  x1 : ThreeThings
+  x2 : ThreeThings
+  x3 : ThreeThings
+
+BouquetNew = Bouquet ThreeThings
+automorphnew : BouquetNew → BouquetNew
+
+automorphnew base = base
+automorphnew (loop x1 i) = (loop x1 ∙ loop x2 ∙ loop x3 ∙ sym (loop x2) ∙ sym (loop x3)) i
+automorphnew (loop x2 i) = loop x2 i
+automorphnew (loop x3 i) = (sym (loop x2) ∙ loop x1 ∙ loop x2) i
+
+
+
+automorphGeneral : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
+automorphGeneral zero b = base
+automorphGeneral (suc zero) base = base
+automorphGeneral (suc zero) (loop x i) = loop x i
+automorphGeneral (suc (suc  n)) base = base
+automorphGeneral (suc (suc n)) (loop (zero , p) i) = loop  ((suc zero) , suc-≤-suc (suc-≤-suc (zero-≤ ))) i
+automorphGeneral (suc (suc n)) (loop (suc zero , p) i) = loop (zero , (suc-≤-suc (≤-suc (zero-≤ )))) i
+automorphGeneral (suc (suc n)) (loop (suc (suc k) , x) i) = loop (suc (suc k) , x) i
+
+
+encodeDecodeAG : (n : ℕ) → (b : Bouquet (Fin n)) → automorphGeneral n (automorphGeneral n b)  ≡ b
+encodeDecodeAG zero base = refl
+encodeDecodeAG zero (loop (x , p) i) j = lemma i j
+  where lemma : Square refl refl refl (loop (x , p)) 
+        lemma = ⊥.rec (¬-<-zero p)
+encodeDecodeAG (suc zero) base = refl
+encodeDecodeAG (suc zero) (loop x i) = refl
+encodeDecodeAG (suc (suc n)) base = refl
+encodeDecodeAG (suc (suc n)) (loop (zero , p) i) j = loop (zero , isProp≤ (suc-≤-suc (≤-suc (zero-≤ ))) p j) i 
+encodeDecodeAG (suc (suc n)) (loop (suc zero , p) i) j = loop (suc zero , isProp≤ (suc-≤-suc (suc-≤-suc (zero-≤ ))) p j) i
+encodeDecodeAG (suc (suc n)) (loop (suc (suc x) , p) i) = refl
+
+
+
+MyIsomoprh : (n : ℕ) → Iso (Bouquet (Fin n)) (Bouquet (Fin n))
+Iso.fun (MyIsomoprh n) = automorphGeneral n 
+Iso.inv (MyIsomoprh n) = automorphGeneral n 
+Iso.rightInv (MyIsomoprh n) = encodeDecodeAG n
+Iso.leftInv (MyIsomoprh n) = encodeDecodeAG n
+    
+ 

--- a/CQTS/BraidGroups.agda
+++ b/CQTS/BraidGroups.agda
@@ -7,6 +7,8 @@ open import Cubical.Data.Empty as ⊥
 
 open import Cubical.Algebra.Group
 open import Cubical.HITs.Bouquet
+open import Cubical.HITs.S1
+
 open import Cubical.Data.Fin
 open import Cubical.Data.Nat using (ℕ ; zero ; suc ; _+_ ; znots)
 open import Cubical.Data.Nat.Order
@@ -144,6 +146,15 @@ circleHelper (suc k) (suc (suc n)) (loop i) = ( {! circleHelper ? ? ? !} ∙ loo
 circMap : (n : ℕ) →  S¹ → Bouquet (Fin n)
 circMap n s = circleHelper n n s
 
-BouquetCircStr : (n : ℕ) → TypeWithStr {! ℓ !} {!   !} 
-BouquetCircStr n = Bouquet (Fin n) , circMap
+-- Defining a circle structure
+CircleStructure :  Type → Type 
+CircleStructure A = {!   !}
 
+-- CircleEquivStr : StrEquiv CircleStructure 
+-- CircleEquivStr A B f = ?
+
+-- CircleUnivalentStr :  
+-- CircleUnivalentStr f =  ?
+
+BouquetCircStr : (n : ℕ) → TypeWithStr _ {! CircleStructure !}
+BouquetCircStr n = Bouquet (Fin n) , circMap

--- a/CQTS/BraidGroups.agda
+++ b/CQTS/BraidGroups.agda
@@ -148,13 +148,12 @@ circMap n s = circleHelper n n s
 
 -- Defining a circle structure
 CircleStructure :  Type → Type 
-CircleStructure A = {!   !}
+CircleStructure A = Σ (n : ℕ) (f : S¹ → Bouquet A) , (f ≡ circMap n)
+-- CircleEquivStr : {!   !}
+-- CircleEquivStr A B f = {!   !}
 
--- CircleEquivStr : StrEquiv CircleStructure 
--- CircleEquivStr A B f = ?
+-- CircleUnivalentStr :  {!   !}
+-- CircleUnivalentStr f =  {!   !}
 
--- CircleUnivalentStr :  
--- CircleUnivalentStr f =  ?
-
-BouquetCircStr : (n : ℕ) → TypeWithStr _ {! CircleStructure !}
-BouquetCircStr n = Bouquet (Fin n) , circMap
+BouquetCircStr : (n : ℕ) → TypeWithStr _ CircleStructure
+BouquetCircStr n = Bouquet (Fin n) , circMap n 

--- a/CQTS/BraidGroups.agda
+++ b/CQTS/BraidGroups.agda
@@ -89,6 +89,7 @@ automorphismGenInv (suc (suc n)) (loop (zero , _) i) = loop (suc zero , suc-≤-
 automorphismGenInv (suc (suc n)) (loop (suc zero , p) i) = (sym (loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ )) )) ∙ loop (zero , (suc-≤-suc (≤-suc (zero-≤ )))) ∙ loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ )))) i
 automorphismGenInv (suc (suc n)) (loop (suc (suc x) , p) i) = (loop (suc (suc x) , p) i)
 
+-- hardCase : cong automorphismGen n (cong automorphismGen n ())
 
 encodeDecodeAutomorph : (n : ℕ) → (b : Bouquet (Fin n)) → automorphismGenInv n (automorphismGen n b)  ≡ b
 encodeDecodeAutomorph zero base = refl
@@ -97,8 +98,8 @@ encodeDecodeAutomorph zero (loop (x , p) i) j =  lemma i j
         lemma = ⊥.rec (¬-<-zero p) 
 encodeDecodeAutomorph (suc zero) b = refl
 encodeDecodeAutomorph (suc (suc n)) base = refl
-encodeDecodeAutomorph (suc (suc n)) (loop (zero , p) i) j = {!   !}
-encodeDecodeAutomorph (suc (suc n)) (loop (suc zero , p) i)  = {!   !}
+encodeDecodeAutomorph (suc (suc n)) (loop (zero , p) i) = {!   !}
+encodeDecodeAutomorph (suc (suc n)) (loop (suc zero , p) i) j  = loop (suc zero , isProp≤ (suc-≤-suc (suc-≤-suc (zero-≤ ))) p j) i
 encodeDecodeAutomorph (suc (suc n)) (loop (suc (suc x) , p) i) = refl
 
 

--- a/CQTS/BraidGroups.agda
+++ b/CQTS/BraidGroups.agda
@@ -1,9 +1,9 @@
 module CQTS.BraidGroups where
 
 open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Function
 open import Cubical.Data.Empty as ⊥
 
 open import Cubical.Algebra.Group
@@ -11,68 +11,165 @@ open import Cubical.HITs.Bouquet
 open import Cubical.HITs.S1
 
 open import Cubical.Data.Fin
-open import Cubical.Data.Nat using (ℕ ; zero ; suc ; _+_ ; znots; predℕ)
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; _+_ ; znots)
 open import Cubical.Data.Nat.Order
-open import Cubical.Data.FinData.Base using(predFin)
 
 open import Cubical.Foundations.SIP
 open import Cubical.Structures.Pointed
 open import Cubical.HITs.S1.Base
 
-private
-  variable
-    ℓ : Level
+open import Cubical.Relation.Nullary
 
+open import Cubical.Foundations.Path
+open import Cubical.Foundations.GroupoidLaws
 
-automorphGeneral : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
-automorphGeneral zero b = base
-automorphGeneral (suc zero) base = base
-automorphGeneral (suc zero) (loop x i) = loop x i
-automorphGeneral (suc (suc  n)) base = base
-automorphGeneral (suc (suc n)) (loop (zero , p) i) = loop  ((suc zero) , suc-≤-suc (suc-≤-suc (zero-≤ ))) i
-automorphGeneral (suc (suc n)) (loop (suc zero , p) i) = loop (zero , (suc-≤-suc (≤-suc (zero-≤ )))) i
-automorphGeneral (suc (suc n)) (loop (suc (suc k) , x) i) = loop (suc (suc k) , x) i
+open import CQTS.BraidGroups.Ars
 
+-- example about the relations without using the bouquet library
 
-encodeDecodeAG : (n : ℕ) → (b : Bouquet (Fin n)) → automorphGeneral n (automorphGeneral n b)  ≡ b
-encodeDecodeAG zero base = refl
-encodeDecodeAG zero (loop (x , p) i) j = lemma i j
+data Bouquet3 : Type where 
+  base : Bouquet3
+  loop1 : base ≡ base
+  loop2 : base ≡ base
+  loop3 : base ≡ base 
+
+auto : Bouquet3 → Bouquet3
+auto base = base
+auto (loop1 i) = (loop1 ∙ loop2 ∙ loop3 ∙ (sym loop2) ∙ (sym loop1)) i
+auto (loop2 i) = loop2 i
+auto (loop3 i) = (sym loop2 ∙ loop1 ∙ loop2) i
+
+data ThreeThings : Type where
+  x1 : ThreeThings
+  x2 : ThreeThings
+  x3 : ThreeThings
+
+BouquetNew = Bouquet ThreeThings
+auto0 : BouquetNew → BouquetNew
+
+auto0 base = base
+auto0 (loop x1 i) = (loop x1 ∙ loop x2 ∙ loop x3 ∙ sym (loop x2) ∙ sym (loop x3)) i
+auto0 (loop x2 i) = loop x2 i
+auto0 (loop x3 i) = (sym (loop x2) ∙ loop x1 ∙ loop x2) i
+
+-- examples using the bouquet library
+
+-- example 1 (or example 0 but with the lib) (the inverse is obviously the same)
+
+-- x₁ → x₂
+-- x₂ → x₁
+-- xᵢ → xᵢ
+
+auto1 : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
+auto1 zero b = base
+auto1 (suc zero) base = base
+auto1 (suc zero) (loop x i) = loop x i
+auto1 (suc (suc n)) base = base
+auto1 (suc (suc n)) (loop (zero , p) i) = loop  ((suc zero) , suc-≤-suc (suc-≤-suc (zero-≤ ))) i
+auto1 (suc (suc n)) (loop (suc zero , p) i) = loop (zero , (suc-≤-suc (≤-suc (zero-≤ )))) i
+auto1 (suc (suc n)) (loop (suc (suc k) , x) i) = loop (suc (suc k) , x) i
+
+encodeDecode1 : (n : ℕ) → (b : Bouquet (Fin n)) → auto1 n (auto1 n b)  ≡ b
+encodeDecode1 zero base = refl
+encodeDecode1 zero (loop (x , p) i) j = lemma i j
   where lemma : Square refl refl refl (loop (x , p)) 
         lemma = ⊥.rec (¬-<-zero p)
-encodeDecodeAG (suc zero) base = refl
-encodeDecodeAG (suc zero) (loop x i) = refl
-encodeDecodeAG (suc (suc n)) base = refl
-encodeDecodeAG (suc (suc n)) (loop (zero , p) i) j = loop (zero , isProp≤ (suc-≤-suc (≤-suc (zero-≤ ))) p j) i 
-encodeDecodeAG (suc (suc n)) (loop (suc zero , p) i) j = loop (suc zero , isProp≤ (suc-≤-suc (suc-≤-suc (zero-≤ ))) p j) i
-encodeDecodeAG (suc (suc n)) (loop (suc (suc x) , p) i) = refl
+encodeDecode1 (suc zero) base = refl
+encodeDecode1 (suc zero) (loop x i) = refl
+encodeDecode1 (suc (suc n)) base = refl
+encodeDecode1 (suc (suc n)) (loop (zero , p) i) j = loop (zero , isProp≤ (suc-≤-suc (≤-suc (zero-≤ ))) p j) i 
+encodeDecode1 (suc (suc n)) (loop (suc zero , p) i) j = loop (suc zero , isProp≤ (suc-≤-suc (suc-≤-suc (zero-≤ ))) p j) i
+encodeDecode1 (suc (suc n)) (loop (suc (suc x) , p) i) = refl
 
+iso1 : (n : ℕ) → Iso (Bouquet (Fin n)) (Bouquet (Fin n))
+Iso.fun (iso1 n) = auto1 n 
+Iso.inv (iso1 n) = auto1 n 
+Iso.rightInv (iso1 n) = encodeDecode1 n
+Iso.leftInv (iso1 n) = encodeDecode1 n
 
--- New Automorphism
+-- Proof that iso1 is an equivalence
 
--- x1 -> x1 x2 x1_1
--- x2 -> x1
--- xi -> xi
+iso1eq : (n : ℕ) → (Bouquet (Fin n)) ≃ (Bouquet (Fin n))
+iso1eq n =  isoToEquiv (iso1 n)
 
-automorphismGen : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
-automorphismGen zero b = base
-automorphismGen (suc zero) b = b
-automorphismGen (suc (suc n)) base = base
-automorphismGen (suc (suc n)) (loop (zero , p) i) = (loop (zero , suc-≤-suc (≤-suc zero-≤)) ∙∙ loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ ))) ∙∙ sym (loop (zero , suc-≤-suc (≤-suc zero-≤)))) i
-automorphismGen (suc (suc n)) (loop (suc zero , p) i) = loop (zero , (suc-≤-suc (≤-suc (zero-≤ )))) i
-automorphismGen (suc (suc n)) (loop (suc (suc x) , p) i) = (loop (suc (suc x) , p) i)
+BouquetStr : (n : ℕ) → TypeWithStr _ PointedStructure
+BouquetStr n = Bouquet (Fin n) , base
 
+iso1ptdEq : (n : ℕ) → BouquetStr n ≃[ PointedEquivStr ] BouquetStr n
+fst (iso1ptdEq n) = iso1eq n
+snd (iso1ptdEq zero) = refl
+snd (iso1ptdEq (suc zero)) = refl
+snd (iso1ptdEq (suc (suc n))) = refl
 
--- Inverse of automorphism
--- y1 -> y2 = x1
--- y2 -> y-2 y1 y2 = x-1 x1x2x-1 x1
--- yi -> yi 
-automorphismGenInv : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
-automorphismGenInv zero b = base
-automorphismGenInv (suc zero) b = b
-automorphismGenInv (suc (suc n)) base = base
-automorphismGenInv (suc (suc n)) (loop (zero , _) i) = loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ ))) i
-automorphismGenInv (suc (suc n)) (loop (suc zero , p) i) = (sym (loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ )) )) ∙∙ loop (zero , (suc-≤-suc (≤-suc (zero-≤ )))) ∙∙ loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ )))) i
-automorphismGenInv (suc (suc n)) (loop (suc (suc x) , p) i) = (loop (suc (suc x) , p) i)
+iso1ptdEqPath : (n : ℕ) → BouquetStr n ≡ BouquetStr n
+iso1ptdEqPath n = pointed-sip (BouquetStr n) (BouquetStr n) (iso1ptdEq n)
+
+-- example 2
+
+-- xᵢ → xᵢ₊₁
+-- xₙ → x₁
+
+-- the inverse:
+-- xₙ → x₁
+-- xᵢ₊₁ → xᵢ
+
+includeStart : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin (suc n))
+includeStart n base = base
+includeStart n (loop (k , p) i) = loop (k , ≤-suc p) i
+
+includeEnd : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin (suc n))
+includeEnd n base = base
+includeEnd n (loop (k , p) i) = loop (suc k , suc-≤-suc p) i
+
+dropStart : (n : ℕ) → Bouquet (Fin (suc n)) → Bouquet (Fin n)
+dropStart n x = {!!}
+
+dropEnd : (n : ℕ) → Bouquet (Fin (suc n)) → Bouquet (Fin n)
+dropEnd n x = {!!}
+
+grabLast : (n : ℕ) → Path (Bouquet (Fin n)) base base
+grabLast zero = {!!}
+grabLast (suc n) = {!!}
+
+auto2 : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
+auto2 n base = base
+auto2 n (loop (zero , _) i) = grabLast n i
+auto2 n (loop (suc k , p) i) = loop (k , suc-< p) i
+
+-- auto2inv : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
+-- auto2inv n base = base
+-- auto2inv n grabLast = helper {!!} {!!} {!!}
+--   where helper : (n : ℕ) → Path (Bouquet (Fin n)) base base → Bouquet (Fin n) → Bouquet (Fin n)
+--         helper n remembered b = {!!}
+-- auto2inv n (loop (k , p) i) = loop (suc k , {!!}) i
+
+-- example 3
+
+-- x₁ → x₁ x₂ x₁⁻¹
+-- x₂ → x₁
+-- xᵢ → xᵢ
+
+-- the inverse:
+
+-- x₁ → x₂
+-- x₂ → x₂⁻¹ x₁ x₂
+-- xᵢ → xᵢ
+
+auto3 : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
+auto3 zero b = base
+auto3 (suc zero) b = b
+auto3 (suc (suc n)) base = base
+auto3 (suc (suc n)) (loop (zero , p) i) = (loop (zero , suc-≤-suc (≤-suc zero-≤)) ∙ loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ ))) ∙ sym (loop (zero , suc-≤-suc (≤-suc zero-≤)))) i
+auto3 (suc (suc n)) (loop (suc zero , p) i) = loop (zero , (suc-≤-suc (≤-suc (zero-≤ )))) i
+auto3 (suc (suc n)) (loop (suc (suc x) , p) i) = (loop (suc (suc x) , p) i)
+
+auto3Inv : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
+auto3Inv zero b = base
+auto3Inv (suc zero) b = b
+auto3Inv (suc (suc n)) base = base
+auto3Inv (suc (suc n)) (loop (zero , _) i) = loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ ))) i
+auto3Inv (suc (suc n)) (loop (suc zero , p) i) = (sym (loop (suc zero , suc-≤-suc(suc-≤-suc(zero-≤)))) ∙ loop (zero , (suc-≤-suc(≤-suc(zero-≤)))) ∙ loop (suc zero , suc-≤-suc(suc-≤-suc(zero-≤)))) i
+auto3Inv (suc (suc n)) (loop (suc (suc x) , p) i) = (loop (suc (suc x) , p) i)
 
 hardCase-lemma : ∀ {ℓ} {A : Type ℓ} {x₁ x₂ x₃ x₄ x₅ x₆ : A}
   {s : x₁ ≡ x₂}
@@ -102,26 +199,26 @@ hardCase-cancelSides {A = A} s p q i j = hcomp faces (p j)
         faces k (j = i1) = rCancel q i k
 
 hardCase : ∀ n p →
-           (λ i → automorphismGenInv (suc (suc n)) (automorphismGen (suc (suc n)) (loop (zero , p) i)))
+           (λ i → auto3Inv (suc (suc n)) (auto3 (suc (suc n)) (loop (zero , p) i)))
            ≡ loop (zero , p)
 hardCase n p =
-  (λ i → automorphismGenInv (suc (suc n)) (automorphismGen (suc (suc n)) (loop (zero , p) i)))
+  (λ i → auto3Inv (suc (suc n)) (auto3 (suc (suc n)) (loop (zero , p) i)))
 
-    ≡⟨ refl ⟩
+    ≡⟨ {!refl!} ⟩
 
-  (λ i → automorphismGenInv (suc (suc n)) ((loop (zero , suc-≤-suc (≤-suc zero-≤))
+  (λ i → auto3Inv (suc (suc n)) ((loop (zero , suc-≤-suc (≤-suc zero-≤))
                                             ∙∙ loop (suc zero , suc-≤-suc (suc-≤-suc zero-≤))
                                             ∙∙ (sym (loop (zero , suc-≤-suc (≤-suc zero-≤))))) i))
 
-    ≡⟨ cong-∙∙ (automorphismGenInv (suc (suc n))) (loop (zero , suc-≤-suc (≤-suc zero-≤)))
+    ≡⟨ cong-∙∙ (auto3Inv (suc (suc n))) (loop (zero , suc-≤-suc (≤-suc zero-≤)))
                                                   (loop (suc zero , suc-≤-suc (suc-≤-suc zero-≤)))
                                                   ((sym (loop (zero , suc-≤-suc (≤-suc zero-≤))))) ⟩
 
-  (cong (automorphismGenInv (suc (suc n))) (loop (zero , suc-≤-suc (≤-suc zero-≤)))
-   ∙∙ cong (automorphismGenInv (suc (suc n))) (loop (suc zero , suc-≤-suc (suc-≤-suc zero-≤)))
-   ∙∙ cong (automorphismGenInv (suc (suc n))) ((sym (loop (zero , suc-≤-suc (≤-suc zero-≤))))))
+  (cong (auto3Inv (suc (suc n))) (loop (zero , suc-≤-suc (≤-suc zero-≤)))
+   ∙∙ cong (auto3Inv (suc (suc n))) (loop (suc zero , suc-≤-suc (suc-≤-suc zero-≤)))
+   ∙∙ cong (auto3Inv (suc (suc n))) ((sym (loop (zero , suc-≤-suc (≤-suc zero-≤))))))
 
-    ≡⟨ refl ⟩
+    ≡⟨ {!refl!} ⟩
 
   (loop (suc zero , _)
    ∙∙ (λ i →    (sym (loop (suc zero , suc-≤-suc (suc-≤-suc zero-≤) ))
@@ -141,39 +238,16 @@ hardCase n p =
   loop (zero , p)
   ∎
 
-encodeDecodeAutomorph : (n : ℕ) → (b : Bouquet (Fin n)) → automorphismGenInv n (automorphismGen n b)  ≡ b
-encodeDecodeAutomorph zero base = refl
-encodeDecodeAutomorph zero (loop (x , p) i) j =  lemma i j
+encodeDecode3 : (n : ℕ) → (b : Bouquet (Fin n)) → auto3Inv n (auto3 n b) ≡ b
+encodeDecode3 zero base = refl
+encodeDecode3 zero (loop (x , p) i) j =  lemma i j
   where lemma : Square refl refl refl (loop (x , p))
         lemma = ⊥.rec (¬-<-zero p)
-encodeDecodeAutomorph (suc zero) b = refl
-encodeDecodeAutomorph (suc (suc n)) base = refl
-encodeDecodeAutomorph (suc (suc n)) (loop (zero , p) i) j = hardCase n p j i
-encodeDecodeAutomorph (suc (suc n)) (loop (suc zero , p) i) j  = loop (suc zero , isProp≤ (suc-≤-suc (suc-≤-suc (zero-≤ ))) p j) i
-encodeDecodeAutomorph (suc (suc n)) (loop (suc (suc x) , p) i) = refl
-
-
-MyIsomoprh : (n : ℕ) → Iso (Bouquet (Fin n)) (Bouquet (Fin n))
-Iso.fun (MyIsomoprh n) = automorphGeneral n 
-Iso.inv (MyIsomoprh n) = automorphGeneral n 
-Iso.rightInv (MyIsomoprh n) = encodeDecodeAG n
-Iso.leftInv (MyIsomoprh n) = encodeDecodeAG n
-    
--- Proof that MyIsomoprh is an equivalence
-MyIsomoprhEquiv : (n : ℕ) → (Bouquet (Fin n)) ≃ (Bouquet (Fin n))
-MyIsomoprhEquiv n =  isoToEquiv (MyIsomoprh n)
-
-BouquetStr : (n : ℕ) → TypeWithStr _ PointedStructure
-BouquetStr n = Bouquet (Fin n) , base
-
-MyIsomoprhPtdEquiv : (n : ℕ) → BouquetStr n ≃[ PointedEquivStr ] BouquetStr n
-fst (MyIsomoprhPtdEquiv n) = MyIsomoprhEquiv n
-snd (MyIsomoprhPtdEquiv zero) = refl
-snd (MyIsomoprhPtdEquiv (suc zero)) = refl
-snd (MyIsomoprhPtdEquiv (suc (suc n))) = refl
-
-MyIsomorphPtdPath : (n : ℕ) → BouquetStr n ≡ BouquetStr n
-MyIsomorphPtdPath n = pointed-sip (BouquetStr n) (BouquetStr n) (MyIsomoprhPtdEquiv n)
+encodeDecode3 (suc zero) b = refl
+encodeDecode3 (suc (suc n)) base = refl
+encodeDecode3 (suc (suc n)) (loop (zero , p) i) j = hardCase n p j i
+encodeDecode3 (suc (suc n)) (loop (suc zero , p) i) j  = loop (suc zero , isProp≤ (suc-≤-suc (suc-≤-suc (zero-≤ ))) p  j) i
+encodeDecode3 (suc (suc n)) (loop (suc (suc x) , p) i) = refl
 
 circleHelper : (k : ℕ) →  (n : ℕ) → (k < n) →  S¹ → Bouquet (Fin n)
 circleHelper k n _ base = base
@@ -181,26 +255,241 @@ circleHelper k zero _ s = base
 circleHelper zero (suc n) _ (loop i) = loop (zero , suc-≤-suc zero-≤) i
 circleHelper (suc k) (suc n) p (loop i) = ( (λ j → circleHelper k (suc n) (suc-< p) (loop j)) ∙ loop (suc k , p )) i
 
+-- cHelper : (k : ℕ) → (n : ℕ) → S¹ → (k < n) → Bouquet (Fin n)
+-- cHelper zero zero base p = base
+-- cHelper zero zero (loop i) p = base
+-- cHelper zero (suc n) base p = base
+-- cHelper zero (suc n) (loop i) p = {!!}
+-- cHelper (suc k) zero base p = base
+-- cHelper (suc k) zero (loop i) p = base
+-- cHelper (suc k) (suc n) base p = base
+-- cHelper (suc k) (suc n) (loop i) p = cHelper {!!} {!!} {!!} p
 
 circMap : (n : ℕ) →  S¹ → Bouquet (Fin n)
 circMap zero s = base
 circMap (suc n) s = circleHelper n (suc n) ≤-refl s
 
 -- Defining a circle structure
-TypeWithLoop :  ∀ {ℓ} → Type (ℓ-suc ℓ)
-TypeWithLoop {ℓ} = Σ[ X ∈ Type ℓ ] (S¹ → X)
+-- TypeWithLoop :  ∀ {ℓ} → Type (ℓ-suc ℓ)
+-- TypeWithLoop {ℓ} = Σ[ X ∈ Type ℓ ] (S¹ → X)
 --  Σ (n : ℕ) (f : S¹ → Bouquet A) , (f ≡ circMap n)
 
 -- CircleStructure : Type ℓ → Type ℓ
 -- CircleStructure X = Σ[ xX ] (S¹ → X)
 
-
 -- BouquetCircStr : (n : ℕ) → TypeWithStr _ {! CircleStructure  !}
--- BouquetCircStr n = Bouquet (Fin n) , circMap n 
+-- BouquetCircStr n = Bouquet (Fin n) , circMap n
 
+-- swappy : (k : ℕ) → (n : ℕ) → (k < n) → (Bouquet (Fin n)) → (Bouquet (Fin n))
+-- swappy k zero p b = base
+-- swappy k (suc zero) p b = base
+-- swappy zero (suc (suc n)) p b = auto1 {! suc suc n  !} {!   !}
+-- swappy (suc k) (suc n) p b = {!   !}
 
-swappy : (k : ℕ) → (n : ℕ) → (k < n) → (Bouquet (Fin n)) → (Bouquet (Fin n))
-swappy k zero p b = base
-swappy k (suc zero) p b = base
-swappy zero (suc (suc n)) p b = automorphGeneral {! suc suc n  !} {!   !}
-swappy (suc k) (suc n) p b = {!   !}
+index1 : (n : ℕ) → Fin (suc (suc n)) → Fin (suc (suc n)) -- we want to swap 0 and 1
+index1 zero f = (suc zero , suc-≤-suc ≤-refl)
+index1 (suc zero) f = (zero , ≤-suc (≤-suc ≤-refl))
+index1 (suc (suc n)) f = (suc (suc n) , ≤-suc ≤-refl)
+
+deleteZero : {n : ℕ} → (j : Fin (suc n)) → (¬ 0 ≡ fst j) → Fin n
+deleteZero j pr = punchOut {i = (zero , suc-≤-suc zero-≤)} {j = j} ({!!}) --  <→≢ pr
+
+indexN : (n : ℕ) (m : Fin (suc n)) → Fin (suc (suc n)) → Fin (suc (suc n)) -- we want to swap m and m + 1
+indexN zero (m , _) f = index1 zero f
+indexN (suc n) (zero , _) f = index1 (suc n) f
+indexN (suc n) (suc m , x) (zero , b) = index1 (suc n) (zero , b)
+indexN (suc n) (suc m , x) (suc a , b) = fsuc (indexN n (m , pred-≤-pred x) (deleteZero (suc a , b) (<→≢ (suc-≤-suc zero-≤))))
+
+bouqueter : {A B : Set} → (A → B) → (Bouquet A → Bouquet B) -- same as bouquet-map in BraidGroups.Ars
+bouqueter f base = base
+bouqueter f (loop x i) = loop (f x) i
+
+bouqueterG : {A : Set} → (A → Path (Bouquet A) base base) → (Bouquet A → Bouquet A)
+bouqueterG f base = base
+bouqueterG f (loop x i) = (f x ∙ loop x ∙ sym (f x)) i
+
+bouqueterA : {A : Set} → (A → Path (Bouquet A) base base) → (Bouquet A → Bouquet A)
+bouqueterA f base = base
+bouqueterA f (loop x i) = f x i
+
+bouq : (n : ℕ) (m : Fin (suc n)) → Bouquet (Fin (suc (suc n))) → Bouquet (Fin (suc (suc n)))
+bouq n m = bouqueter (indexN n m)
+
+auto1new : (n : ℕ) → (Fin (suc (suc n))) → (Path (Bouquet (Fin (suc (suc n)))) base base)
+auto1new zero f = (loop (zero , ≤-suc ≤-refl)) ∙ (loop (suc zero , suc-≤-suc ≤-refl))
+auto1new (suc zero) f = loop (zero , ≤-suc (≤-suc ≤-refl))
+auto1new (suc (suc n)) f = refl
+
+auto1newBouq : (n : ℕ) → Bouquet (Fin (suc (suc n))) → Bouquet (Fin (suc (suc n)))
+auto1newBouq n = bouqueterG (auto1new n)
+
+-- Here is the old definition of Ars and all of its auxiliary functions and proofs.
+-- All of the new auxiliary functions and proofs will either be in this file (after the commented section) or BraidGroups.Ars
+-- Note that uncommenting the following code does not break anything, it's just full of unnecessary goals that are near impossible to solve for now,
+-- which is why they're being rewritten using the new Ars definition. To distinguish between the two version, the older version uses an ' at the end of all names.
+
+-- Ars-index' : (n : ℕ) (r : Fin (suc (suc n))) (s : Fin (suc (suc n))) → (fst r < fst s) → (i : Fin (suc (suc n))) →  Path (Bouquet (Fin (suc (suc n)))) base base
+-- Ars-index' n (zero , a) (zero , b) p i = ⊥.rec (¬-<-zero p)
+-- Ars-index' zero (zero , a) (suc s , b) p (zero , c) = loop (zero , c) ∙ loop (suc zero , ≤-refl) ∙ loop (zero , c) ∙ sym (loop (suc zero , ≤-refl)) ∙ sym (loop (zero , c))
+-- Ars-index' zero (zero , a) (suc s , b) p (suc i , c) = loop (zero , a) ∙ loop (suc zero , ≤-refl) ∙ sym (loop (zero , a))
+-- Ars-index' (suc n) (zero , a) (suc s , b) p (zero , c) = loop (zero , c) ∙ loop (suc s , b) ∙ loop (zero , c) ∙ sym (loop (suc s , b)) ∙ sym (loop (zero , c)) 
+-- Ars-index' (suc n) (zero , a) (suc s , b) p (suc i , c) = helper (s ≟ i)
+--   where helper : Trichotomy s i → base ≡ base
+--         helper (lt q) = refl
+--         helper (eq q) = loop (zero , a) ∙ loop (suc i , c) ∙ sym (loop (zero , a))
+--         helper (gt q) = loop (zero , a) ∙ loop (suc s , b) ∙ sym (loop (zero , a)) ∙ sym (loop (suc s , b)) ∙ loop (suc i , c) ∙ loop (suc s , b) ∙ loop (zero , a) ∙ sym (loop (suc s , b)) ∙ sym (loop (zero , a))
+-- Ars-index' n (suc r , a) (zero , b) p i = ⊥.rec (¬-<-zero p)
+-- Ars-index' zero (suc r , a) (suc s , b) p i = ⊥.rec (¬-<-zero (<≤-trans (pred-≤-pred p) (pred-≤-pred (pred-≤-pred b))))
+-- Ars-index' (suc n) (suc r , a) (suc s , b) p (zero , c) = helper (s ≟ r)
+--   where helper : Trichotomy s r → base ≡ base
+--         helper (lt q) = ⊥.rec (¬m<m (<-trans q (pred-≤-pred p)))
+--         helper (eq q) = ⊥.rec (<→≢ (pred-≤-pred p) (sym q))
+--         helper (gt q) = refl
+-- Ars-index' (suc n) (suc r , a) (suc s , b) p (suc i , c) = cong (bouqueter fsuc) (Ars-index' n (r , pred-≤-pred a) (s , pred-≤-pred b) (pred-≤-pred p) (i , pred-≤-pred c))
+
+-- Ars' : (n : ℕ) (r : Fin (suc (suc n))) (s : Fin (suc (suc n))) → (fst r < fst s) → Bouquet (Fin (suc (suc n))) → Bouquet (Fin (suc (suc n)))
+-- Ars' n r s p = bouqueterA (Ars-index' n r s p)
+
+-- ArsInv-index' : (n : ℕ) (r : Fin (suc (suc n))) (s : Fin (suc (suc n))) → (fst r < fst s) → (i : Fin (suc (suc n))) →  Path (Bouquet (Fin (suc (suc n)))) base base
+-- ArsInv-index' n (zero , a) (zero , b) p i = ⊥.rec (¬-<-zero p)
+-- ArsInv-index' zero (zero , a) (suc s , b) p (zero , c) = sym (loop (suc s , b)) ∙ loop (zero , c) ∙ loop (suc s , b)
+-- ArsInv-index' zero (zero , a) (suc s , b) p (suc i , c) = sym (loop (suc zero , ≤-refl)) ∙ sym (loop (zero , a)) ∙ loop (suc zero , ≤-refl) ∙ loop (zero , a) ∙ loop (suc zero , ≤-refl)
+-- ArsInv-index' n (suc r , a) (zero , b) p i = ⊥.rec (¬-<-zero p)
+-- ArsInv-index' zero (suc r , a) (suc s , b) p i = ⊥.rec (¬-<-zero (<≤-trans (pred-≤-pred p) (pred-≤-pred (pred-≤-pred b)))) 
+-- ArsInv-index' (suc n) (zero , a) (suc s , b) p (zero , c) = sym (loop (suc s , b)) ∙ loop (zero , a) ∙ loop (suc s , b)
+-- ArsInv-index' (suc n) (zero , a) (suc s , b) p (suc i , c) = helper (s ≟ i)
+--    where helper : Trichotomy s i → base ≡ base
+--          helper (lt q) = refl
+--          helper (eq q) = sym (loop (suc i , c)) ∙ sym (loop (zero , a)) ∙ loop (suc i , c) ∙ loop (zero , a) ∙ loop (suc i , c)
+--          helper (gt q) = sym (loop (suc s , b)) ∙ sym (loop (zero , a)) ∙ loop (suc s , b) ∙ loop (zero , a) ∙ loop (suc i , c) ∙ sym (loop (zero , a)) ∙ sym (loop (suc s , b)) ∙ loop (zero , a) ∙ loop (suc s , b)
+-- ArsInv-index' (suc n) (suc r , a) (suc s , b) p (zero , c) = helper (s ≟ r)
+--   where helper : Trichotomy s r → base ≡ base
+--         helper (lt q) = ⊥.rec (¬m<m (<-trans q (pred-≤-pred p)))
+--         helper (eq q) = ⊥.rec (<→≢ (pred-≤-pred p) (sym q))
+--         helper (gt q) = refl
+-- ArsInv-index' (suc n) (suc r , a) (suc s , b) p (suc i , c) = cong (bouqueter fsuc) (ArsInv-index' n (r , pred-≤-pred a) (s , pred-≤-pred b) (pred-≤-pred p) (i , pred-≤-pred c))
+
+-- ArsInv' : (n : ℕ) (r : Fin (suc (suc n))) (s : Fin (suc (suc n))) → (fst r < fst s) → Bouquet (Fin (suc (suc n))) → Bouquet (Fin (suc (suc n)))
+-- ArsInv' n r s p = bouqueterA (ArsInv-index' n r s p)
+
+-- productAll' : (n : ℕ) → Path (Bouquet (Fin (suc (suc n)))) base base
+-- productAll' zero = refl
+-- productAll' (suc n) = loop (zero , suc-≤-suc zero-≤) ∙ cong (bouqueter fsuc) (productAll' n)
+
+-- ArsProduct' : (n : ℕ) → (r : Fin (suc (suc n))) → (s : Fin (suc (suc n))) → (p : fst r < fst s) → cong (Ars' n r s p) (productAll' n) ≡ productAll' n
+-- ArsProduct' n (zero , a) (zero , b) p = ⊥.rec (¬-<-zero p)
+-- ArsProduct' zero (zero , a) (suc s , b) p = refl
+-- ArsProduct' zero (suc r , a) (zero , b) p = refl
+-- ArsProduct' zero (suc r , a) (suc s , b) p = refl
+-- ArsProduct' (suc n) (zero , a) (suc s , b) p = 
+
+--            cong (Ars' (suc n) (zero , a) (suc s , b) p)
+--              (loop (zero , suc-≤-suc zero-≤) ∙
+--              (λ i → bouqueter fsuc (productAll' n i)))        
+
+--             ≡⟨ cong-∙ (Ars' (suc n) (zero , a) (suc s , b) p) (loop (zero , suc-≤-suc zero-≤)) ((λ i → bouqueter fsuc (productAll' n i))) ⟩
+
+--            ((cong (Ars' (suc n) (zero , a) (suc s , b) p) (loop (zero , suc-≤-suc zero-≤)))
+--                ∙ (cong (Ars' (suc n) (zero , a) (suc s , b) p) (λ i → bouqueter fsuc (productAll' n i))))
+
+--             ≡⟨ refl ⟩
+
+--            ((loop (zero , suc-≤-suc (≤-suc zero-≤)) ∙ loop (suc s , b) ∙ loop (zero , suc-≤-suc (≤-suc zero-≤)) ∙ sym (loop (suc s , b)) ∙ sym (loop (zero , suc-≤-suc (≤-suc zero-≤))) )
+--               ∙ (cong (Ars' (suc n) (zero , a) (suc s , b) p) (λ i → bouqueter fsuc (productAll' n i))))
+
+--             ≡⟨ {!!} ⟩
+
+--            {!!}
+
+--             ≡⟨ {!!} ⟩
+
+--            loop (zero , suc-≤-suc zero-≤) ∙ (λ i → bouqueter fsuc (productAll' n i))
+
+--           ∎
+
+-- ArsProduct' (suc n) (suc r , a) (zero , b) p = ⊥.rec (¬-<-zero p)
+-- ArsProduct' (suc n) (suc r , a) (suc s , b) p = helper (s ≟ r)
+--   where helper : Trichotomy s r →  cong (Ars' (suc n) (suc r , a) (suc s , b) p) (productAll' (suc n)) ≡ productAll' (suc n)
+--         helper (lt q) = ⊥.rec (¬m<m (<-trans q (pred-≤-pred p)))
+--         helper (eq q) = ⊥.rec (<→≢ (pred-≤-pred p) (sym q))
+--         helper (gt q) =  
+
+--           cong (Ars' (suc n) (suc r , a) (suc s , b) p)
+--           (loop (zero , suc-≤-suc zero-≤) ∙
+--           (λ i → bouqueter fsuc (productAll' n i)))
+
+--             ≡⟨ cong-∙ ((Ars' (suc n) (suc r , a) (suc s , b) p)) ((loop (zero , suc-≤-suc zero-≤))) ((λ i → bouqueter fsuc (productAll' n i))) ⟩
+
+--           (cong (Ars' (suc n) (suc r , a) (suc s , b) p)
+--           (loop (zero , suc-≤-suc zero-≤) ) ∙ ( cong (Ars' (suc n) (suc r , a) (suc s , b) p)
+--           (λ i → bouqueter fsuc (productAll' n i))) )
+
+--             ≡⟨ {!!} ⟩
+
+--           {!!}
+
+--             ≡⟨ {!!} ⟩
+
+--           loop (zero , suc-≤-suc zero-≤) ∙ (λ i → bouqueter fsuc (productAll' n i))
+
+--           ∎
+
+-- proofInv' : (n : ℕ) (r : Fin (suc (suc n))) (s : Fin (suc (suc n))) → (p : fst r < fst s) → (Ars' n r s p) ∘ (ArsInv' n r s p) ≡ idfun _
+-- proofInv' n r (zero , b) p = ⊥.rec (¬-<-zero p)
+-- proofInv' zero (zero , a) (suc s , b) p =
+
+--         Ars' zero (zero , a) (suc s , b) p ∘ ArsInv' zero (zero , a) (suc s , b) p
+
+--              ≡⟨ refl ⟩
+
+--             bouqueterA (Ars-index' zero (zero , a) (suc s , b) p) ∘ bouqueterA (ArsInv-index' zero (zero , a) (suc s , b) p)
+
+--              ≡⟨ {!!} ⟩
+
+--             {!!}
+
+--              ≡⟨ {!!} ⟩
+
+         
+--          idfun (Bouquet (Fin 2))
+
+--          ∎
+         
+-- proofInv' zero (suc r , a) (suc s , b) p = ⊥.rec (¬-<-zero (<≤-trans (pred-≤-pred p) (pred-≤-pred (pred-≤-pred b))))
+-- proofInv' (suc n) (zero , a) (suc s , b) p = {!!}
+-- proofInv' (suc n) (suc r , a) (suc s , b) p = helper (s ≟ r)
+--   where helper : Trichotomy s r →  (Ars' (suc n) (suc r , a) (suc s , b) p) ∘ (ArsInv' (suc n) (suc r , a) (suc s , b) p) ≡ idfun _
+--         helper (lt q) = ⊥.rec (¬m<m (<-trans q (pred-≤-pred p)))
+--         helper (eq q) = ⊥.rec (<→≢ (pred-≤-pred p) (sym q))
+--         helper (gt q) =
+
+--           Ars' (suc n) (suc r , a) (suc s , b) p ∘
+--            ArsInv' (suc n) (suc r , a) (suc s , b) p
+
+--             ≡⟨ refl ⟩
+
+--           bouqueterA (Ars-index' (suc n) (suc r , a) (suc s , b) p) ∘ bouqueterA (ArsInv-index' (suc n) (suc r , a) (suc s , b) p)
+
+--             ≡⟨ {!!} ⟩
+
+--           {!!}
+
+--             ≡⟨ {!!} ⟩
+
+--           idfun (Bouquet (Fin (suc (suc (suc n)))))
+
+--           ∎
+
+-- All the previous proofs using the new definition of Ars and its inverse (provided in BraidGroups.Ars)
+
+productAll : (n : ℕ) → Path (Bouquet (Fin n)) base base
+productAll zero = refl
+productAll (suc n) = loop (zero , suc-≤-suc zero-≤) ∙ cong (bouquet-map fsuc) (productAll n) -- bouquet-map is the same as bouqueter
+
+ArsProduct : {n : ℕ} → (r s : Fin n) → (p : fst r < fst s) → cong (Ars r s p) (productAll n) ≡ productAll n
+ArsProduct r (zero , b) p = ⊥.rec (¬-<-zero p)
+ArsProduct (zero , a) (suc s , b) p = {!  !}
+ArsProduct (suc r , a) (suc s , b) p = {!   !}
+
+proofInv : {n : ℕ} → (r s : Fin n) → (p : fst r < fst s) → (Ars r s p) ∘ (ArsInv r s p) ≡ idfun _
+proofInv r s p = {!   !}

--- a/CQTS/BraidGroups.agda
+++ b/CQTS/BraidGroups.agda
@@ -11,6 +11,8 @@ open import Cubical.Data.Fin
 open import Cubical.Data.Nat using (ℕ ; zero ; suc ; _+_ ; znots)
 open import Cubical.Data.Nat.Order
 
+open import Cubical.Foundations.SIP
+open import Cubical.Structures.Pointed
 
 
 data Bouquet3 : Type where 
@@ -64,6 +66,42 @@ encodeDecodeAG (suc (suc n)) (loop (suc zero , p) i) j = loop (suc zero , isProp
 encodeDecodeAG (suc (suc n)) (loop (suc (suc x) , p) i) = refl
 
 
+-- New Automorphism
+
+automorphismGen : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
+automorphismGen zero b = base
+automorphismGen (suc zero) b = b
+automorphismGen (suc (suc n)) base = base
+automorphismGen (suc (suc n)) (loop (zero , p) i) = (loop (zero , suc-≤-suc (≤-suc zero-≤)) ∙ loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ ))) ∙ sym (loop (zero , suc-≤-suc (≤-suc zero-≤)))) i
+automorphismGen (suc (suc n)) (loop (suc zero , p) i) = loop (zero , (suc-≤-suc (≤-suc (zero-≤ )))) i
+automorphismGen (suc (suc n)) (loop (suc (suc x) , p) i) = (loop (suc (suc x) , p) i)
+
+
+-- Inverse of automorphism
+-- y1 -> y2 = x1
+-- y2 -> y-2 y1 y2 = x-1 x1x2x-1 x1
+-- yi -> yi 
+automorphismGenInv : (n : ℕ) → Bouquet (Fin n) → Bouquet (Fin n)
+automorphismGenInv zero b = base
+automorphismGenInv (suc zero) b = b
+automorphismGenInv (suc (suc n)) base = base
+automorphismGenInv (suc (suc n)) (loop (zero , _) i) = loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ ))) i
+automorphismGenInv (suc (suc n)) (loop (suc zero , p) i) = (sym (loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ )) )) ∙ loop (zero , (suc-≤-suc (≤-suc (zero-≤ )))) ∙ loop (suc zero , suc-≤-suc (suc-≤-suc (zero-≤ )))) i
+automorphismGenInv (suc (suc n)) (loop (suc (suc x) , p) i) = (loop (suc (suc x) , p) i)
+
+
+encodeDecodeAutomorph : (n : ℕ) → (b : Bouquet (Fin n)) → automorphismGenInv n (automorphismGen n b)  ≡ b
+encodeDecodeAutomorph zero base = refl
+encodeDecodeAutomorph zero (loop (x , p) i) j =  lemma i j
+  where lemma : Square refl refl refl (loop (x , p)) 
+        lemma = ⊥.rec (¬-<-zero p) 
+encodeDecodeAutomorph (suc zero) b = refl
+encodeDecodeAutomorph (suc (suc n)) base = refl
+encodeDecodeAutomorph (suc (suc n)) (loop (zero , p) i) j = {!   !}
+encodeDecodeAutomorph (suc (suc n)) (loop (suc zero , p) i)  = {!   !}
+encodeDecodeAutomorph (suc (suc n)) (loop (suc (suc x) , p) i) = refl
+
+
 
 MyIsomoprh : (n : ℕ) → Iso (Bouquet (Fin n)) (Bouquet (Fin n))
 Iso.fun (MyIsomoprh n) = automorphGeneral n 
@@ -71,4 +109,18 @@ Iso.inv (MyIsomoprh n) = automorphGeneral n
 Iso.rightInv (MyIsomoprh n) = encodeDecodeAG n
 Iso.leftInv (MyIsomoprh n) = encodeDecodeAG n
     
- 
+-- Proof that MyIsomoprh is an equivalence
+MyIsomoprhEquiv : (n : ℕ) → (Bouquet (Fin n)) ≃ (Bouquet (Fin n))
+MyIsomoprhEquiv n =  isoToEquiv (MyIsomoprh n)
+
+BouquetStr : (n : ℕ) → TypeWithStr _ PointedStructure
+BouquetStr n = Bouquet (Fin n) , base
+
+MyIsomoprhPtdEquiv : (n : ℕ) → BouquetStr n ≃[ PointedEquivStr ] BouquetStr n
+fst (MyIsomoprhPtdEquiv n) = MyIsomoprhEquiv n
+snd (MyIsomoprhPtdEquiv zero) = refl
+snd (MyIsomoprhPtdEquiv (suc zero)) = refl
+snd (MyIsomoprhPtdEquiv (suc (suc n))) = refl
+
+MyIsomorphPtdPath : (n : ℕ) → BouquetStr n ≡ BouquetStr n
+MyIsomorphPtdPath n = pointed-sip (BouquetStr n) (BouquetStr n) (MyIsomoprhPtdEquiv n)

--- a/CQTS/BraidGroups/Ars.agda
+++ b/CQTS/BraidGroups/Ars.agda
@@ -27,7 +27,6 @@ bouquet-map : ∀ {A B : Type ℓ} → (A → B) → Bouquet A → Bouquet B
 bouquet-map f base = base
 bouquet-map f (loop x i) = loop (f x) i
 
-
 -- This is `fsuc`, but keeping `zero` at `zero`.
 fstretch : ∀ {n} → Fin (suc n) → Fin (suc (suc n))
 fstretch (zero , p) = (zero , ≤-suc p)
@@ -47,7 +46,7 @@ A01-index {suc (suc n)} p (suc zero , px) = loop (0 , suc-≤-suc zero-≤)
 A01-index {suc (suc n)} p (suc (suc x) , px) = refl
 -- Impossible cases:
 A01-index {zero} p x = ⊥.rec (¬-<-zero p)
-A01-index {suc zero} p x = ⊥.rec (¬m<m p )
+A01-index {suc zero} p x = ⊥.rec (¬m<m p)
 
 A0s-index : {n : ℕ} → (s : Fin n) → (0 < fst s) → Fin n → Path (Bouquet (Fin n)) base base
 A0s-index {suc (suc n)} (suc zero , ps) p x = A01-index (suc-≤-suc (suc-≤-suc zero-≤)) x
@@ -80,3 +79,43 @@ Ars-index {zero} (suc r , pr) (suc s , ps) p x = ⊥.rec (¬-<-zero pr)
 
 Ars : {n : ℕ} → (r s : Fin n) → (fst r < fst s) → Bouquet (Fin n) → Bouquet (Fin n)
 Ars r s p = conj-constructor (Ars-index r s p)
+
+A01Inv-index : {n : ℕ} → (1 < n) → Fin n → Path (Bouquet (Fin n)) base base
+A01Inv-index {suc (suc n)} p (zero , px) = sym (loop (1 , suc-≤-suc (suc-≤-suc zero-≤)))
+A01Inv-index {suc (suc n)} p (suc zero , px) = sym (loop (1 , suc-≤-suc (suc-≤-suc zero-≤))) ∙ sym (loop (0 , suc-≤-suc zero-≤))
+A01Inv-index {suc (suc n)} p (suc (suc x) , px) = refl
+-- Impossible cases:
+A01Inv-index {zero} p x = ⊥.rec (¬-<-zero p)
+A01Inv-index {suc zero} p x = ⊥.rec (¬m<m p)
+
+A0sInv-index : {n : ℕ} → (s : Fin n) → (0 < fst s) → Fin n → Path (Bouquet (Fin n)) base base
+A0sInv-index {suc (suc n)} (suc zero , ps) p x = A01Inv-index (suc-≤-suc (suc-≤-suc zero-≤)) x
+A0sInv-index {suc (suc n)} (suc (suc s) , ps) p (zero , px) = cong (bouquet-map fstretch) (A0sInv-index (suc s , pred-≤-pred ps) (suc-≤-suc zero-≤) (zero , suc-≤-suc zero-≤))
+A0sInv-index {suc (suc n)} (suc (suc s) , ps) p (suc zero , px) =
+  sym (loop (1 , suc-≤-suc (suc-≤-suc zero-≤))) ∙ sym (loop (0 , suc-≤-suc zero-≤))
+  ∙ loop (1 , suc-≤-suc (suc-≤-suc zero-≤)) ∙ loop (0 , suc-≤-suc zero-≤)
+A0sInv-index {suc (suc n)} (suc (suc s) , ps) p (suc (suc x) , px) = cong (bouquet-map fstretch) (A0sInv-index (suc s , pred-≤-pred ps) (suc-≤-suc zero-≤) (suc x , pred-≤-pred px))
+
+-- Impossible cases:
+A0sInv-index {zero} s p b = ⊥.rec (¬Fin0 s)
+A0sInv-index {suc zero} (zero , ps) p b = ⊥.rec (¬-<-zero p)
+A0sInv-index {suc zero} (suc s , ps) p b = ⊥.rec (¬-<-zero (pred-≤-pred ps))
+A0sInv-index {suc (suc n)} (zero , ps) p (x , px) = ⊥.rec (¬-<-zero p)
+
+ArsInv-index : {n : ℕ} → (r s : Fin n) → (fst r < fst s) → Fin n → Path (Bouquet (Fin n)) base base
+ArsInv-index {suc n} (zero , pr) (suc s , ps) p = A0sInv-index (suc s , ps) p
+ArsInv-index {suc n} (suc r , pr) (suc s , ps) p (zero , px) = refl
+ArsInv-index {suc n} (suc r , pr) (suc s , ps) p (suc x , px)
+  = cong (bouquet-map fsuc) (ArsInv-index (r , pred-≤-pred pr)
+                                       (s , pred-≤-pred ps)
+                                       (pred-≤-pred p)
+                                       (x , pred-≤-pred px))
+
+-- remaining cases are impossible:
+ArsInv-index (zero , pr) (zero , ps) p x = ⊥.rec (¬-<-zero p)
+ArsInv-index {zero} (zero , pr) (suc s , ps) p x = ⊥.rec (¬-<-zero ps)
+ArsInv-index (suc r , pr) (zero , ps) p x = ⊥.rec (¬-<-zero p)
+ArsInv-index {zero} (suc r , pr) (suc s , ps) p x = ⊥.rec (¬-<-zero pr)
+
+ArsInv : {n : ℕ} → (r s : Fin n) → (fst r < fst s) → Bouquet (Fin n) → Bouquet (Fin n)
+ArsInv r s p = conj-constructor (ArsInv-index r s p)

--- a/CQTS/BraidGroups/Ars.agda
+++ b/CQTS/BraidGroups/Ars.agda
@@ -1,0 +1,82 @@
+module CQTS.BraidGroups.Ars where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Data.Empty as ⊥
+
+open import Cubical.Algebra.Group
+open import Cubical.HITs.Bouquet
+open import Cubical.HITs.S1
+
+open import Cubical.Data.Fin
+open import Cubical.Data.Nat using (ℕ ; zero ; suc ; _+_ ; znots; predℕ)
+open import Cubical.Data.Nat.Order
+open import Cubical.Data.FinData.Base using(predFin)
+
+open import Cubical.Foundations.SIP
+open import Cubical.Structures.Pointed
+open import Cubical.HITs.S1.Base
+
+private
+  variable
+    ℓ : Level
+
+bouquet-map : ∀ {A B : Type ℓ} → (A → B) → Bouquet A → Bouquet B
+bouquet-map f base = base
+bouquet-map f (loop x i) = loop (f x) i
+
+
+-- This is `fsuc`, but keeping `zero` at `zero`.
+fstretch : ∀ {n} → Fin (suc n) → Fin (suc (suc n))
+fstretch (zero , p) = (zero , ≤-suc p)
+fstretch n = fsuc n
+
+-- bouquet-suc : ∀ {n} → (Bouquet (Fin n)) → (Bouquet (Fin (suc n)))
+-- bouquet-suc base = base
+-- bouquet-suc (loop x i) = {!loop (fsuc x) i!}
+
+conj-constructor : ∀ {n} → (Fin n → Path (Bouquet (Fin n)) base base) → (Bouquet (Fin n) → Bouquet (Fin n))
+conj-constructor f base = base
+conj-constructor f (loop x i) = (f x ∙∙ loop x ∙∙ sym (f x)) i
+
+A01-index : {n : ℕ} → (1 < n) → Fin n → Path (Bouquet (Fin n)) base base
+A01-index {suc (suc n)} p (zero , px) = loop (0 , suc-≤-suc zero-≤) ∙ loop (1 , suc-≤-suc (suc-≤-suc zero-≤))
+A01-index {suc (suc n)} p (suc zero , px) = loop (0 , suc-≤-suc zero-≤)
+A01-index {suc (suc n)} p (suc (suc x) , px) = refl
+-- Impossible cases:
+A01-index {zero} p x = ⊥.rec (¬-<-zero p)
+A01-index {suc zero} p x = ⊥.rec (¬m<m p )
+
+A0s-index : {n : ℕ} → (s : Fin n) → (0 < fst s) → Fin n → Path (Bouquet (Fin n)) base base
+A0s-index {suc (suc n)} (suc zero , ps) p x = A01-index (suc-≤-suc (suc-≤-suc zero-≤)) x
+A0s-index {suc (suc n)} (suc (suc s) , ps) p (zero , px) = cong (bouquet-map fstretch) (A0s-index (suc s , pred-≤-pred ps) (suc-≤-suc zero-≤) (zero , suc-≤-suc zero-≤))
+A0s-index {suc (suc n)} (suc (suc s) , ps) p (suc zero , px) =
+  loop (0 , suc-≤-suc zero-≤) ∙ loop (1 , suc-≤-suc (suc-≤-suc zero-≤))
+  ∙ sym (loop (0 , suc-≤-suc zero-≤)) ∙ sym (loop (1 , suc-≤-suc (suc-≤-suc zero-≤)))
+A0s-index {suc (suc n)} (suc (suc s) , ps) p (suc (suc x) , px) = cong (bouquet-map fstretch) (A0s-index (suc s , pred-≤-pred ps) (suc-≤-suc zero-≤) (suc x , pred-≤-pred px))
+
+-- Impossible cases:
+A0s-index {zero} s p b = ⊥.rec (¬Fin0 s)
+A0s-index {suc zero} (zero , ps) p b = ⊥.rec (¬-<-zero p)
+A0s-index {suc zero} (suc s , ps) p b = ⊥.rec (¬-<-zero (pred-≤-pred ps))
+A0s-index {suc (suc n)} (zero , ps) p (x , px) = ⊥.rec (¬-<-zero p)
+
+Ars-index : {n : ℕ} → (r s : Fin n) → (fst r < fst s) → Fin n → Path (Bouquet (Fin n)) base base
+Ars-index {suc n} (zero , pr) (suc s , ps) p = A0s-index (suc s , ps) p
+Ars-index {suc n} (suc r , pr) (suc s , ps) p (zero , px) = refl
+Ars-index {suc n} (suc r , pr) (suc s , ps) p (suc x , px)
+  = cong (bouquet-map fsuc) (Ars-index (r , pred-≤-pred pr)
+                                       (s , pred-≤-pred ps)
+                                       (pred-≤-pred p)
+                                       (x , pred-≤-pred px))
+
+-- remaining cases are impossible:
+Ars-index (zero , pr) (zero , ps) p x = ⊥.rec (¬-<-zero p)
+Ars-index {zero} (zero , pr) (suc s , ps) p x = ⊥.rec (¬-<-zero ps)
+Ars-index (suc r , pr) (zero , ps) p x = ⊥.rec (¬-<-zero p)
+Ars-index {zero} (suc r , pr) (suc s , ps) p x = ⊥.rec (¬-<-zero pr)
+
+Ars : {n : ℕ} → (r s : Fin n) → (fst r < fst s) → Bouquet (Fin n) → Bouquet (Fin n)
+Ars r s p = conj-constructor (Ars-index r s p)

--- a/CQTS/BraidGroups/InductiveBraidGroup.agda
+++ b/CQTS/BraidGroups/InductiveBraidGroup.agda
@@ -1,4 +1,4 @@
-module InductiveBraidGroup where
+module CQTS.BraidGroups.InductiveBraidGroup where
 
 open import Cubical.Foundations.Prelude
 

--- a/CQTS/BraidGroups/InductiveBraidGroup.agda
+++ b/CQTS/BraidGroups/InductiveBraidGroup.agda
@@ -1,0 +1,23 @@
+module InductiveBraidGroup where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Nat using (ℕ; zero; suc; predℕ; _+_)
+open import Cubical.Data.Nat as ℕ
+open import Cubical.Data.Nat.Order
+open import Cubical.Data.Fin
+open import Cubical.Data.Empty as ⊥
+
+data BBraidGroup : (n : ℕ) → Type where
+  base  : BBraidGroup zero
+  ι : ∀ {n} → BBraidGroup n → BBraidGroup (suc n)
+  σ : ∀ {n} → ℕ.elim {A = BBraidGroup} base (λ n → ι) n ≡ ℕ.elim {A = BBraidGroup} base (λ n → ι) n
+
+  comm : ∀ {n} (p : ℕ.elim {A = BBraidGroup} base (λ n → ι) n ≡ ℕ.elim {A = BBraidGroup} base (λ n → ι) n) →
+    Square σ σ (λ i → ι (ι (p i))) (λ i → ι (ι (p i)))
+
+  pull-common : ∀ {n} → Path (BBraidGroup (suc n))
+                             (ℕ.elim {A = BBraidGroup} base (λ n → ι) (suc n))
+                             (ℕ.elim {A = BBraidGroup} base (λ n → ι) (suc n))
+  pull-left : ∀ {n} → Square σ (cong ι σ) σ (pull-common {n})
+  pull-right : ∀ {n} → Square (cong ι σ) σ (cong ι σ) (pull-common {n})

--- a/CQTS/BraidGroups/TaffyStructure.agda
+++ b/CQTS/BraidGroups/TaffyStructure.agda
@@ -1,0 +1,29 @@
+module CQTS.BraidGroups.TaffyStructure where
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Fin
+open import Cubical.Data.Sigma
+
+open import Cubical.HITs.S1
+open import Cubical.HITs.Bouquet
+
+open import Cubical.Structures.Macro
+open import Cubical.Structures.Auto
+
+open import CQTS.BraidGroups
+
+module _ {ℓ} (n : ℕ) where
+
+  taffyDesc : Desc ℓ ℓ ℓ
+  taffyDesc = autoDesc (λ (X : Type ℓ) → (S¹ → X) × (Fin n → (S¹ → X)))
+
+  open Macro ℓ taffyDesc public renaming
+    ( structure to TaffyStructure
+    ; equiv to TaffyEquivStr
+    ; univalent to taffyUnivalentStr
+    )
+
+-- ConditionOne : 
+
+BouquetInstance : ∀ n → TaffyStructure n (Bouquet (Fin n))
+BouquetInstance n = circMap n , {!   !}


### PR DESCRIPTION
The only changes are the ones in the commit message: I edited the names of the functions in the BraidGroups.agda file, organized the code, add the new definitions of proofInv and ArsProduct proofs based on the new definition provided in BraidGroups.Ars.agda, also added the ArsInv definition to BraidGroups.Ars.agda, fixed a mistake in the first line of the InteractiveBraidGroup.agda (the module name). The new functions are not complete still, but I changed the names of the old ones and commented them. All new and old functions are in the BraidGroups.agda file.